### PR TITLE
fix: format and refactor to resolve Pylint warnings

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install pylint
     - name: Analysing the code with pylint
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
         pip install -r requirements.txt
-        pip install pylint
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/gitcord/bot.py
+++ b/gitcord/bot.py
@@ -45,17 +45,13 @@ class GitCordBot(commands.Bot):
 
     async def _load_cogs(self) -> None:
         """Load all bot cogs."""
-        try:
-            # Load the general cog
-            await self.load_extension("gitcord.cogs.general")
-            logger.info("Loaded general cog")
+        # Load the general cog
+        await self.load_extension("gitcord.cogs.general")
+        logger.info("Loaded general cog")
 
-            # Add more cogs here as they are created
-            # await self.load_extension("gitcord.cogs.git")
-            # await self.load_extension("gitcord.cogs.admin")
-
-        except Exception as e:
-            logger.error("Failed to load cogs: %s", e)
+        # Add more cogs here as they are created
+        # await self.load_extension("gitcord.cogs.git")
+        # await self.load_extension("gitcord.cogs.admin")
 
     async def on_command_error(self, context, error):
         """Global command error handler."""
@@ -82,8 +78,6 @@ async def main() -> None:
         logger.error("Invalid Discord token! Please check your DISCORD_TOKEN in the .env file.")
     except ValueError as e:
         logger.error("Configuration error: %s", e)
-    except Exception as e:
-        logger.error("Error starting bot: %s", e)
 
 
 def run_bot() -> None:

--- a/gitcord/bot.py
+++ b/gitcord/bot.py
@@ -53,7 +53,7 @@ class GitCordBot(commands.Bot):
         # await self.load_extension("gitcord.cogs.git")
         # await self.load_extension("gitcord.cogs.admin")
 
-    async def on_command_error(self, context, error):
+    async def on_command_error(self, context, error):  # pylint: disable=arguments-differ
         """Global command error handler."""
         logger.error("Global command error: %s", error)
         if isinstance(error, commands.CommandNotFound):

--- a/gitcord/cogs/general.py
+++ b/gitcord/cogs/general.py
@@ -250,11 +250,15 @@ class General(commands.Cog):
                 'nsfw': channel_config.get('nsfw', False)
             }
 
-            # Set channel type
+            # Set position if specified
+            if 'position' in channel_config:
+                channel_kwargs['position'] = channel_config['position']
+
+            # Create the channel based on type
             if channel_config['type'].lower() == 'text':
-                channel_type = discord.ChannelType.text
+                new_channel = await ctx.guild.create_text_channel(**channel_kwargs)
             elif channel_config['type'].lower() == 'voice':
-                channel_type = discord.ChannelType.voice
+                new_channel = await ctx.guild.create_voice_channel(**channel_kwargs)
             else:
                 embed = create_embed(
                     title="❌ Invalid Channel Type",
@@ -265,16 +269,6 @@ class General(commands.Cog):
                 await ctx.send(embed=embed)
                 return
 
-            # Set position if specified
-            if 'position' in channel_config:
-                channel_kwargs['position'] = channel_config['position']
-
-            # Create the channel based on type
-            if channel_type == discord.ChannelType.text:
-                new_channel = await ctx.guild.create_text_channel(**channel_kwargs)
-            else:  # voice channel
-                new_channel = await ctx.guild.create_voice_channel(**channel_kwargs)
-
             # Create success embed
             embed = create_embed(
                 title="✅ Channel Created",
@@ -283,9 +277,9 @@ class General(commands.Cog):
             )
 
             # Add fields manually
-            embed.add_field(name="Name", value=channel_config['name'], inline=True)
-            embed.add_field(name="Type", value=channel_config['type'], inline=True)
-            embed.add_field(name="NSFW", value=str(channel_config.get('nsfw', False)), inline=True)
+            embed.add_field(name="Name", value=channel_kwargs['name'], inline=True)
+            embed.add_field(name="Type", value=channel_kwargs['type'], inline=True)
+            embed.add_field(name="NSFW", value=channel_kwargs['nsfw'], inline=True)
             embed.add_field(name="Topic", value=channel_config.get('topic', 'No topic set'),
                             inline=False)
 

--- a/gitcord/cogs/general.py
+++ b/gitcord/cogs/general.py
@@ -3,18 +3,18 @@ General commands cog for GitCord bot.
 Contains basic utility commands.
 """
 
-import re
-import yaml
 import os
+import re
 
 import discord
-from discord.ext import commands
-from discord import app_commands
 import requests
+import yaml
 from bs4 import BeautifulSoup
+from discord import app_commands
+from discord.ext import commands
 
-from ..utils.logger import main_logger as logger
 from ..utils.helpers import format_latency, create_embed
+from ..utils.logger import main_logger as logger
 
 
 class General(commands.Cog):
@@ -39,7 +39,7 @@ class General(commands.Cog):
             # Fetch the webpage
             headers = {
                 'User-Agent': ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-                              '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36')
+                               '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36')
             }
             response = requests.get(url, headers=headers, timeout=10)
             response.raise_for_status()
@@ -118,7 +118,7 @@ class General(commands.Cog):
             # Fetch the webpage
             headers = {
                 'User-Agent': ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-                              '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36')
+                               '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36')
             }
             response = requests.get(url, headers=headers, timeout=10)
             response.raise_for_status()
@@ -221,7 +221,7 @@ class General(commands.Cog):
     async def createchannel(self, ctx: commands.Context) -> None:
         """Create a channel based on properties defined in a YAML file."""
         yaml_path = "/home/user/Projects/gitcord-template/community/off-topic.yaml"
-        
+
         try:
             # Check if the user has permission to manage channels
             if not ctx.author.guild_permissions.manage_channels:
@@ -274,7 +274,8 @@ class General(commands.Cog):
             else:
                 embed = create_embed(
                     title="❌ Invalid Channel Type",
-                    description=f"Channel type '{channel_config['type']}' is not supported. Use 'text' or 'voice'.",
+                    description=f"Channel type '{channel_config['type']}' is not supported. "
+                                "Use 'text' or 'voice'.",
                     color=discord.Color.red()
                 )
                 await ctx.send(embed=embed)
@@ -296,15 +297,17 @@ class General(commands.Cog):
                 description=f"Successfully created channel: {new_channel.mention}",
                 color=discord.Color.green()
             )
-            
+
             # Add fields manually
             embed.add_field(name="Name", value=channel_config['name'], inline=True)
             embed.add_field(name="Type", value=channel_config['type'], inline=True)
             embed.add_field(name="NSFW", value=str(channel_config.get('nsfw', False)), inline=True)
-            embed.add_field(name="Topic", value=channel_config.get('topic', 'No topic set'), inline=False)
+            embed.add_field(name="Topic", value=channel_config.get('topic', 'No topic set'),
+                            inline=False)
 
             await ctx.send(embed=embed)
-            logger.info("Channel '%s' created successfully by %s", channel_config['name'], ctx.author)
+            logger.info("Channel '%s' created successfully by %s", channel_config['name'],
+                        ctx.author)
 
         except yaml.YAMLError as e:
             embed = create_embed(
@@ -340,7 +343,8 @@ class General(commands.Cog):
             logger.error("Unexpected error in createchannel command: %s", e)
 
     @createchannel.error
-    async def createchannel_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
+    async def createchannel_error(self, ctx: commands.Context,
+                                  error: commands.CommandError) -> None:
         """Handle errors for the createchannel command."""
         if isinstance(error, commands.MissingPermissions):
             embed = create_embed(

--- a/gitcord/cogs/general.py
+++ b/gitcord/cogs/general.py
@@ -3,7 +3,6 @@ General commands cog for GitCord bot.
 Contains basic utility commands.
 """
 
-import os
 import re
 
 import discord
@@ -13,7 +12,7 @@ from bs4 import BeautifulSoup
 from discord import app_commands
 from discord.ext import commands
 
-from ..utils.helpers import format_latency, create_embed
+from ..utils.helpers import format_latency, create_embed, parse_channel_config
 from ..utils.logger import main_logger as logger
 
 
@@ -233,31 +232,16 @@ class General(commands.Cog):
                 await ctx.send(embed=embed)
                 return
 
-            # Check if YAML file exists
-            if not os.path.exists(yaml_path):
+            try:
+                channel_config = parse_channel_config(yaml_path)
+            except ValueError as e:
                 embed = create_embed(
-                    title="❌ File Not Found",
-                    description=f"YAML file not found at: {yaml_path}",
+                    title="❌ Invalid YAML",
+                    description=str(e),
                     color=discord.Color.red()
                 )
                 await ctx.send(embed=embed)
                 return
-
-            # Read and parse YAML file
-            with open(yaml_path, 'r', encoding='utf-8') as file:
-                channel_config = yaml.safe_load(file)
-
-            # Validate required fields
-            required_fields = ['name', 'type']
-            for field in required_fields:
-                if field not in channel_config:
-                    embed = create_embed(
-                        title="❌ Invalid YAML",
-                        description=f"Missing required field: {field}",
-                        color=discord.Color.red()
-                    )
-                    await ctx.send(embed=embed)
-                    return
 
             # Prepare channel creation parameters
             channel_kwargs = {

--- a/gitcord/utils/helpers.py
+++ b/gitcord/utils/helpers.py
@@ -1,11 +1,12 @@
 """
 Helper utilities for GitCord bot.
 """
-
+import os
 from datetime import datetime
 from typing import Optional, Union
 
 import discord
+import yaml
 
 
 def format_latency(latency: float) -> str:
@@ -97,3 +98,20 @@ def format_time_delta(seconds: float) -> str:
         return f"{minutes:.1f}m"
     hours = seconds / 3600
     return f"{hours:.1f}h"
+
+
+def parse_channel_config(yaml_path: str) -> dict:
+    """Parse and validate the YAML configuration file."""
+    if not os.path.exists(yaml_path):
+        raise ValueError(f"YAML file not found at: {yaml_path}")
+
+    with open(yaml_path, 'r', encoding='utf-8') as file:
+        channel_config = yaml.safe_load(file)
+
+    # Validate required fields
+    required_fields = ['name', 'type']
+    for field in required_fields:
+        if field not in channel_config:
+            raise ValueError(f"Missing required field: {field}")
+
+    return channel_config

--- a/gitcord/utils/logger.py
+++ b/gitcord/utils/logger.py
@@ -35,8 +35,8 @@ def setup_logger(name: str = "gitcord", level: int = logging.INFO) -> logging.Lo
     return logger
 
 
-def log_error(log_instance: logging.Logger, error: Exception, context: Optional[str] = None) -> None:
-
+def log_error(log_instance: logging.Logger, error: Exception,
+              context: Optional[str] = None) -> None:
     """
     Log an error with context.
 
@@ -49,6 +49,7 @@ def log_error(log_instance: logging.Logger, error: Exception, context: Optional[
     if context:
         message = f"{context} - {message}"
     log_instance.error(message, exc_info=True)  # pylint: disable=line-too-long
+
 
 # Default logger instance
 main_logger = setup_logger()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pylint>=3.3.7
+setuptools>=80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 discord.py>=2.5.2
 python-dotenv==1.0.0
 requests>=2.31.0
-beautifulsoup4>=4.12.0 
+beautifulsoup4>=4.12.0
+PyYAML>=6.0.2


### PR DESCRIPTION
Fixes #6. Here's a general list of what I did:

- Ran PyCharm's default formatter over the bot files to fix import sorting, line lengths, trailing whitespace, etc.
- Removed broad `Exception` catching in `bot.py`.
- Abstracted the logic for parsing channel configs from the `createchannel` command in the `general` cog to a helper function.
- Simplified some of the conditional logic in the `createchannel` command.
- Added PyYAML to `requirements.txt` as it was used but not defined as a dependency.
- Created `requirements-dev.txt` with Pylint and Setuptools.
- Edited the Pylint workflow on GitHub Actions to install project/dev dependencies before linting. Also bumped the Python versions in the workflow matrix to 3.10-3.13, as Pylint's latest version doesn't support below 3.10.

There are a few additional comments in my commit descriptions to explain my changes, but let me know if you have any other questions or concerns!