### PR TITLE
Resolve #19: manual command sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Once it's ready, you'll have to link the **GitCord** bot to your own repository,
 - **Version-Controlled Configuration**: Store your Discord server configuration in a Git repository
 - **Automatic Sync**: Webhook-based synchronization when configuration changes are pushed to GitHub
 - **Manual Pull**: Use `/gitcord pull` command to manually sync configuration changes
+- **Command Syncing**: Use `/synccommands` to manually synchronize slash commands
 - **Category and Channel Management**: Organize your server structure through YAML configuration files
 
 ## Project Status

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once it's ready, you'll have to link the **GitCord** bot to your own repository,
 - **Version-Controlled Configuration**: Store your Discord server configuration in a Git repository
 - **Automatic Sync**: Webhook-based synchronization when configuration changes are pushed to GitHub
 - **Manual Pull**: Use `/gitcord pull` command to manually sync configuration changes
-- **Command Syncing**: Use `/synccommands` to manually synchronize slash commands
+- **Command Syncing**: Use `/synccommands` (slash) or `!synccommands` (prefix) to manually synchronize slash commands
 - **Category and Channel Management**: Organize your server structure through YAML configuration files
 
 ## Project Status

--- a/README_MODULAR.md
+++ b/README_MODULAR.md
@@ -40,7 +40,7 @@ gitcord/
 ### Enhanced Features
 - **Rich Embeds**: Beautiful Discord embeds for responses
 - **Structured Logging**: Proper logging with formatting
-- **Command Syncing**: Use the `/synccommands` slash command to synchronize application commands
+- **Command Syncing**: Use the `/synccommands` (slash) or `!synccommands` (prefix) command to synchronize application commands
 - **Error Recovery**: Graceful error handling and recovery
 
 ## 📦 Installation

--- a/README_MODULAR.md
+++ b/README_MODULAR.md
@@ -40,7 +40,7 @@ gitcord/
 ### Enhanced Features
 - **Rich Embeds**: Beautiful Discord embeds for responses
 - **Structured Logging**: Proper logging with formatting
-- **Command Syncing**: Automatic slash command synchronization
+- **Command Syncing**: Use the `/synccommands` slash command to synchronize application commands
 - **Error Recovery**: Graceful error handling and recovery
 
 ## 📦 Installation

--- a/src/gitcord/bot.py
+++ b/src/gitcord/bot.py
@@ -38,8 +38,7 @@ class GitCordBot(commands.Bot):
         # Load cogs
         await self._load_cogs()
 
-        # Sync command tree
-        await self.tree.sync()
+        # Command syncing is now done manually using the `/synccommands` slash command.
 
         logger.info("Bot setup completed")
 

--- a/src/gitcord/cogs/general.py
+++ b/src/gitcord/cogs/general.py
@@ -312,6 +312,28 @@ class General(commands.Cog):
         )
         await interaction.response.send_message(embed=embed)
 
+    @app_commands.command(name="synccommands", description="Manually sync slash commands")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def synccommands(self, interaction: discord.Interaction) -> None:
+        """Synchronize application commands for this guild."""
+        await interaction.response.defer(thinking=True, ephemeral=True)
+        try:
+            synced = await self.bot.tree.sync(guild=interaction.guild)
+            await interaction.followup.send(
+                f"Synced {len(synced)} command(s).",
+                ephemeral=True
+            )
+            logger.info(
+                "Manually synced %d command(s) in guild: %s",
+                len(synced),
+                interaction.guild.name if interaction.guild else "N/A"
+            )
+        except discord.DiscordException as e:
+            logger.error("Failed to sync commands: %s", e)
+            await interaction.followup.send(
+                f"Failed to sync commands: {e}", ephemeral=True
+            )
+
     @app_commands.command(name="createcategory", description="Create a category and its channels from YAML configuration")
     @app_commands.describe(yaml_path="Path to the category YAML file (optional)")
     async def createcategory_slash(self, interaction: discord.Interaction, yaml_path: str = None) -> None:

--- a/src/gitcord/events.py
+++ b/src/gitcord/events.py
@@ -30,8 +30,8 @@ class EventHandler:  # pylint: disable=too-few-public-methods
         # Send restart message to guilds
         await self._send_restart_messages()
 
-        # Sync slash commands
-        await self._sync_commands()
+        # Slash commands are no longer automatically synced here.
+        # Use the `/synccommands` command to sync manually if needed.
 
     async def _send_restart_messages(self) -> None:
         """Send restart messages to available text channels."""


### PR DESCRIPTION
## Summary
- stop syncing commands in `on_ready`
- stop syncing commands in bot setup
- add `/synccommands` to sync commands manually
- document manual sync command

## Testing
- `python -m compileall -q src`
- `pylint src/gitcord/cogs/general.py src/gitcord/events.py src/gitcord/bot.py` *(fails: Unable to import 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68795deecfd48324b6617a58ea684c91